### PR TITLE
refactor: corrected annotations.js to annotations.json

### DIFF
--- a/dist/_annotations/annotations.json
+++ b/dist/_annotations/annotations.json
@@ -1,4 +1,4 @@
-var comments = {
+{
 "comments" : [
 	{
 		"el": "header[role=banner]",
@@ -31,4 +31,4 @@ var comments = {
 		"comment": "<p>The hero area highlights one major story using a large image and a captivating headline.</p>"
 	}
 ]
-};
+}


### PR DESCRIPTION
`annotations.js` should be called `annotations.json`. It contains JSON, not JavaScript.

For more info, see pattern-lab/patternlab-node#836.

~A prerequisite for this change would be https://github.com/pattern-lab/patternlab-node/pull/1402~